### PR TITLE
Add bidirectional sync for Pocket and Raindrop

### DIFF
--- a/src/PocketGateway.ts
+++ b/src/PocketGateway.ts
@@ -9,6 +9,32 @@ interface GetPocketItemsResponse {
     since: number
 }
 
+// Partial interface with properties that might be used
+interface PocketItem {
+    item_id: string
+    resolved_id: string
+    given_url: string
+    given_title: string
+    favorite: string // Represented as a digit (ex. "0")
+    status: string // Represented as a digit (ex. "0")
+    time_added: string // Epoch seconds
+    time_updated: string // Epoch seconds
+    sort_id: number
+    resolved_title: string
+    resolved_url: string
+    domain_metadata: {
+        name: string
+        logo: string
+        greyscale_logo: string
+    }
+    excerpt: string
+}
+
+interface AddItemResponse {
+    item: any
+    status: string
+}
+
 export class PocketGateway {
     private consumerKey: string
     private accessToken: string
@@ -47,9 +73,32 @@ export class PocketGateway {
         const { list } = data
 
         const items = Object.keys(list).map((itemId) => {
-            return list[itemId]
+            return list[itemId] as PocketItem
         })
 
         return items
+    }
+
+    public async addItem({ url }: { url: string }) {
+        const results = await fetch("https://getpocket.com/v3/add", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                consumer_key: this.consumerKey,
+                access_token: this.accessToken,
+                url: encodeURI(url),
+                tags: ['sync']
+            })
+        })
+
+        const data = await results.json() as AddItemResponse
+
+        if (!results.ok) {
+            throw new Error(`(${results.status}) Something went wrong with adding the item: ${results.body}`)
+        }
+
+        return data
     }
 }

--- a/src/RaindropGateway.ts
+++ b/src/RaindropGateway.ts
@@ -2,9 +2,22 @@ import fetch from 'node-fetch'
 
 interface GetRaindropsResponse {
     result: boolean
-    items: any[]
+    items: Raindrop[]
     count: number
     collectionId: number
+}
+
+interface Raindrop {
+    excerpt: string
+    note: string
+    type: string // An enum
+    cover: string // A URL
+    tags: string[]
+    removed: boolean
+    title: string
+    link: string
+    created: string // ISO timestamp
+    lastUpdate: string // ISO timestamp
 }
 
 export class RaindropGateway {
@@ -24,5 +37,23 @@ export class RaindropGateway {
         const data = await results.json() as GetRaindropsResponse
 
         return data.items
+    }
+
+    public async addRaindrop({ link }: { link: string }) {
+        const results = await fetch(`https://api.raindrop.io/rest/v1/raindrop`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${this.token}`
+            },
+            body: JSON.stringify({
+                link,
+                pleaseParse: {},
+                tags: ["sync"]
+            })
+        })
+
+        const data = await results.json()
+
+        return data
     }
 }


### PR DESCRIPTION
PR adds logic to sync between Pocket and Raindrop from the last sync time with their respective APIs.